### PR TITLE
グローバルCSSからKlee Oneフォントの定義を削除し、レイアウトファイルでGoogleフォントをインポートして使用するように変更しま…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,12 +1,5 @@
 @import "tailwindcss";
-@font-face {
-  font-display: swap;
-  font-family: "Klee One";
-  font-style: normal;
-  font-weight: 400;
-  src: url("../../public/fonts/klee-one-v12-japanese_latin-regular.woff2")
-    format("woff2");
-}
+
 /* カスタム変数 */
 :root {
   --main-blue: #2f506c;
@@ -17,14 +10,6 @@
   --text-dark: #1a1816;
   --text-gray: #4a3c3c;
   --accent-beige: #f5f5f3;
-
-  --radius-small: 12px;
-  --radius-medium: 20px;
-  --radius-large: 28px;
-
-  --padding-small: 12px 16px;
-  --padding-medium: 20px 24px;
-  --padding-large: 32px 40px;
 }
 
 /* グローバルスタイル */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,9 +3,16 @@ import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import Script from "next/script";
 import { generatePageMetadata, generateOrganizationSchema } from "@/lib/seo";
+import { Klee_One } from "next/font/google";
 import "./globals.css";
 
 export const metadata: Metadata = generatePageMetadata({ path: "/" });
+
+const kleeOne = Klee_One({
+  weight: ["400", "600"],
+  subsets: ["latin"],
+  display: "swap",
+});
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
…した。これにより、フォント管理が一元化され、スタイルの整合性が向上しました。